### PR TITLE
Chore/avoid sidekiq retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Flipper::Notifications.configure do |config|
   slack_webhook = Flipper::Notifications::Webhooks::Slack.new(url: ENV.fetch("SLACK_WEBHOOK_URL"))
 
   config.notifiers = [
-    Flipper::Notifications::Notifiers::WebhookNotifier.new(webhook: webhook)
+    Flipper::Notifications::Notifiers::WebhookNotifier.new(webhook: slack_webhook)
   ]
 end
 ```

--- a/lib/flipper/notifications/jobs/webhook_notification_job.rb
+++ b/lib/flipper/notifications/jobs/webhook_notification_job.rb
@@ -7,6 +7,8 @@ module Flipper
   module Notifications
     class WebhookNotificationJob < ActiveJob::Base
 
+      sidekiq_options(retry: 0) if respond_to?(:sidekiq_options)
+
       # TODO: Pull queue from configuration?
       # queue_as :low
 


### PR DESCRIPTION
## Background

I noticed that we were making quite a few API calls to Slack from our production environment. There are underlying errors such as rate limits and requests to Slack with blocks that are too long that merit their own fixes. Nevertheless, I discovered that the webhook notification jobs were being retried by ActiveJob and Sidekiq. We don't need these failed jobs to run through Sidekiq's weeks-long retry strategy.

This PR opts out of Sidekiq retries in the `Flipper::Notifications:: WebhookNotificationJob` by default.