### PR TITLE
Account for Sidekiq vs. Flipper Notifications load order when configuring sidekiq_options

### DIFF
--- a/lib/flipper/notifications/jobs/webhook_notification_job.rb
+++ b/lib/flipper/notifications/jobs/webhook_notification_job.rb
@@ -7,7 +7,9 @@ module Flipper
   module Notifications
     class WebhookNotificationJob < ActiveJob::Base
 
-      sidekiq_options(retry: 0) if respond_to?(:sidekiq_options)
+      def self.disable_sidekiq_retries
+        sidekiq_options(retry: 0) if respond_to?(:sidekiq_options)
+      end
 
       # TODO: Pull queue from configuration?
       # queue_as :low

--- a/lib/flipper/notifications/railtie.rb
+++ b/lib/flipper/notifications/railtie.rb
@@ -17,6 +17,10 @@ module Flipper
         ]
       end
 
+      config.after_initialize do
+        WebhookNotificationJob.disable_sidekiq_retries
+      end
+
     end
   end
 end


### PR DESCRIPTION
## Background

I noticed that we were making quite a few API calls to Slack from our production environment. There are underlying errors such as rate limits and requests to Slack with blocks that are too long that merit their own fixes. Nevertheless, I discovered that the webhook notification jobs were being retried by ActiveJob and Sidekiq. We don't need these failed jobs to run through Sidekiq's weeks-long retry strategy.

In #4 , I failed to consider Rails' load order between Sidekiq and this gem.  The `Flipper::Notifications::WebhookNotificationJob` was being loaded before Sidekiq had added the `sidekiq_options` method to `ActiveJob::Base`.  Therefore the `WebhookNotificationJob` did not yet respond to `sidekiq_options` when it was trying to disable Sidekiq retries 😩 .

This PR hooks into the Flipper Notifications Railtie to disable sidekiq retries after the Rails application has finished initializing.