### PR TITLE
Update flipper to 1.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     flipper-notifications (0.1.3)
       activesupport (~> 7.0)
-      flipper (~> 0.24)
+      flipper (~> 1.3)
       httparty (~> 0.17)
 
 GEM
@@ -21,7 +21,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     bundler-gem_version_tasks (0.2.1)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.3)
     crack (0.4.5)
       rexml
     debug (1.7.1)
@@ -29,7 +29,7 @@ GEM
       reline (>= 0.3.1)
     diff-lcs (1.5.0)
     docile (1.4.0)
-    flipper (0.28.3)
+    flipper (1.3.0)
       concurrent-ruby (< 2)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -37,14 +37,14 @@ GEM
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
-    i18n (1.12.0)
+    i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
     irb (1.6.2)
       reline (>= 0.3.0)
     json (2.6.3)
     mini_mime (1.1.5)
-    minitest (5.16.3)
+    minitest (5.22.3)
     multi_xml (0.6.0)
     parallel (1.22.1)
     parser (3.1.3.0)
@@ -88,7 +88,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    tzinfo (2.0.5)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.3.0)
     webmock (3.18.1)
@@ -98,6 +98,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-23
 
 DEPENDENCIES
   activejob (~> 7.0)

--- a/flipper-notifications.gemspec
+++ b/flipper-notifications.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "activesupport", "~> 7.0"
-  spec.add_runtime_dependency "flipper", "~> 1.3"
+  spec.add_runtime_dependency "flipper", ">= 0.24", "< 2.0"
   spec.add_runtime_dependency "httparty", "~> 0.17"
 
   spec.add_development_dependency "bundler"

--- a/flipper-notifications.gemspec
+++ b/flipper-notifications.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "activesupport", "~> 7.0"
-  spec.add_runtime_dependency "flipper", "~> 0.24"
+  spec.add_runtime_dependency "flipper", "~> 1.3"
   spec.add_runtime_dependency "httparty", "~> 0.17"
 
   spec.add_development_dependency "bundler"

--- a/spec/rails/defaults/Gemfile.lock
+++ b/spec/rails/defaults/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: ../../..
   specs:
-    flipper-notifications (0.1.0)
+    flipper-notifications (0.1.3)
       activesupport (~> 7.0)
-      flipper (~> 0.24)
+      flipper (~> 1.3)
       httparty (~> 0.17)
 
 GEM
@@ -78,7 +78,7 @@ GEM
     bootsnap (1.15.0)
       msgpack (~> 1.2)
     builder (3.2.4)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.3)
     crass (1.0.6)
     date (3.3.3)
     debug (1.7.0)
@@ -89,12 +89,12 @@ GEM
       dotenv (= 2.8.1)
       railties (>= 3.2)
     erubi (1.11.0)
-    flipper (0.26.0)
+    flipper (1.3.0)
       concurrent-ruby (< 2)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    httparty (0.20.0)
-      mime-types (~> 3.0)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -111,9 +111,6 @@ GEM
       net-smtp
     marcel (1.0.2)
     method_source (1.0.0)
-    mime-types (3.4.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2022.0105)
     mini_mime (1.1.2)
     minitest (5.16.3)
     msgpack (1.6.0)
@@ -127,12 +124,12 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
-    nio4r (2.5.8)
-    nokogiri (1.13.10-arm64-darwin)
+    nio4r (2.7.1)
+    nokogiri (1.16.4-arm64-darwin)
       racc (~> 1.4)
-    puma (5.6.5)
+    puma (5.6.8)
       nio4r (~> 2.0)
-    racc (1.6.1)
+    racc (1.7.3)
     rack (2.2.4)
     rack-test (2.0.2)
       rack (>= 1.3)
@@ -181,6 +178,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-23
 
 DEPENDENCIES
   bootsnap

--- a/spec/rails/defaults/test/integration/flipper_notifications_test.rb
+++ b/spec/rails/defaults/test/integration/flipper_notifications_test.rb
@@ -7,6 +7,7 @@ class TestFlipperNotifications < Minitest::Test
   include ActiveJob::TestHelper
 
   def setup
+    Flipper.instance = Flipper.new(Flipper::Adapters::Memory.new, instrumenter: ActiveSupport::Notifications)
     @feature_name = :test_feature
   end
 


### PR DESCRIPTION
- Loosens gemspec requirement to allow any pre-2.0 version
- Updates tests to run against flipper 1.3.0