### PR TITLE
[gh-8] Refer to Users as Actors

### DIFF
--- a/lib/flipper/notifications/feature_event.rb
+++ b/lib/flipper/notifications/feature_event.rb
@@ -45,10 +45,10 @@ module Flipper
 
           settings << "- Groups: #{to_sentence(feature.enabled_groups.map(&:name).sort)}" if feature.enabled_groups.any?
 
-          settings << "- Users: #{to_sentence(feature.actors_value.sort)}" if feature.actors_value.any?
+          settings << "- Actors: #{to_sentence(feature.actors_value.sort)}" if feature.actors_value.any?
 
           if feature.percentage_of_actors_value.positive?
-            settings << "- #{feature.percentage_of_actors_value}% of users"
+            settings << "- #{feature.percentage_of_actors_value}% of actors"
           end
 
           settings << "- #{feature.percentage_of_time_value}% of the time" if feature.percentage_of_time_value.positive?

--- a/spec/flipper/notifications/feature_event_spec.rb
+++ b/spec/flipper/notifications/feature_event_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Flipper::Notifications::FeatureEvent do
       it "includes enabled actors" do
         user = User.new(id: 1)
         feature.enable_actor(user)
-        expect(markdown).to match(/Users: #{user.flipper_id}/)
+        expect(markdown).to match(/Actors: #{user.flipper_id}/)
       end
 
       it "includes two actors" do
@@ -128,7 +128,7 @@ RSpec.describe Flipper::Notifications::FeatureEvent do
         feature.enable_actor(user)
         feature.enable_actor(user2)
 
-        expect(markdown).to match(/Users: #{user.flipper_id} and #{user2.flipper_id}/)
+        expect(markdown).to match(/Actors: #{user.flipper_id} and #{user2.flipper_id}/)
       end
 
       it "includes several actors" do
@@ -139,12 +139,12 @@ RSpec.describe Flipper::Notifications::FeatureEvent do
         feature.enable_actor(user2)
         feature.enable_actor(user3)
 
-        expect(markdown).to match(/Users: #{user.flipper_id}, #{user2.flipper_id} and #{user3.flipper_id}/)
+        expect(markdown).to match(/Actors: #{user.flipper_id}, #{user2.flipper_id} and #{user3.flipper_id}/)
       end
 
       it "includes percentage of actors" do
         feature.enable_percentage_of_actors(50)
-        expect(markdown).to match(/50% of users/)
+        expect(markdown).to match(/50% of actors/)
       end
 
       it "includes percentage of time" do

--- a/spec/flipper/notifications/webhooks/slack_spec.rb
+++ b/spec/flipper/notifications/webhooks/slack_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Flipper::Notifications::Webhooks::Slack do
     subject(:notify_webhook) { webhook.notify(event: event, context_markdown: context_markdown) }
 
     let(:url) { "https://api.slack.test" }
-    let(:user) { nil }
     let(:webhook) { described_class.new(url: url) }
     let(:stub_request) { WebMock.stub_request(:post, url) }
     let(:context_markdown) { "Test (changed by: Unknown)" }

--- a/spec/flipper/notifications_spec.rb
+++ b/spec/flipper/notifications_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe Flipper::Notifications do
   end
 
   describe "notifications" do
-    let(:admin) { users(:admin) }
     let(:webhook) { described_class::Webhooks::Slack.new(url: "test url") }
     let(:notifier) { double("notifier", call: nil) }
 


### PR DESCRIPTION
Fixes #8 

Actors aren't always Users, so labeling them as such in notifications can be misleading.  This PR updates the verbiage in our notifications to use "actors" instead of "users".