### PR TITLE
Convenience method to temporarily disable notifications

### DIFF
--- a/lib/flipper/notifications.rb
+++ b/lib/flipper/notifications.rb
@@ -38,6 +38,15 @@ module Flipper
     def unsubscribe!
       ActiveSupport::Notifications.unsubscribe(@subscriber)
     end
+
+    # WARNING: this implementation is not thread-safe
+    def disabled
+      previous_value = configuration.enabled
+      configuration.enabled = false
+      yield
+    ensure
+      configuration.enabled = previous_value
+    end
   end
 end
 

--- a/spec/flipper/notifications_spec.rb
+++ b/spec/flipper/notifications_spec.rb
@@ -139,5 +139,25 @@ RSpec.describe Flipper::Notifications do
         expect(notifier).not_to have_received(:call)
       end
     end
+
+    describe "temporarily disabling notifications" do
+      it "does not notify on events within the block passed to #disabled" do
+        Flipper::Notifications.disabled do
+          Flipper.add(:test)
+        end
+
+        expect(notifier).not_to have_received(:call)
+      end
+
+      it "restores the previously configured value after the block is run" do
+        described_class.configuration.enabled = true
+        described_class.disabled { Flipper.add(:test) }
+        expect(described_class.configuration.enabled).to be true
+
+        described_class.configuration.enabled = false
+        described_class.disabled { Flipper.add(:test) }
+        expect(described_class.configuration.enabled).to be false
+      end
+    end
   end
 end


### PR DESCRIPTION
Convenience method to temporarily disable notifications, which can be useful when performing bulk changes to flipper features.

```ruby
Flipper::Notifications.disabled do
  Project.find_each do |project|
    Flipper.enable :some_feature, project
  end
end
```

Note that this won't be thread-safe. If that's a necessary constraint, we'll have to come up with a different approach.