### PR TITLE
Fixing CI build

### DIFF
--- a/.github/workflows/rails-tests.yml
+++ b/.github/workflows/rails-tests.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - '*'
+  schedule:
+    - cron: "0 6 * * *" # 6 A.M.
 
 jobs:
   test:

--- a/.github/workflows/ruby-tests.yml
+++ b/.github/workflows/ruby-tests.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - '*'
+  schedule:
+    - cron: "0 6 * * *" # 6 A.M.
 
 jobs:
   test:

--- a/.github/workflows/ruby-tests.yml
+++ b/.github/workflows/ruby-tests.yml
@@ -14,9 +14,9 @@ jobs:
     strategy:
       matrix:
         ruby_version:
-          - 3.0
-          - 3.1
-          - 3.2
+          - '3.0'
+          - '3.1'
+          - '3.2'
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,4 +113,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.11
+   2.6.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,4 +113,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.6.3
+   2.3.11

--- a/lib/flipper/notifications/jobs/webhook_notification_job.rb
+++ b/lib/flipper/notifications/jobs/webhook_notification_job.rb
@@ -17,7 +17,7 @@ module Flipper
       retry_on Webhooks::NetworkError,
                Webhooks::ServerError,
                attempts: 3,
-               wait:     ActiveJob.version < "7.1" ? :exponentially_longer : :polynomially_longer
+               wait:     ActiveJob.version < Gem::Version.new("7.1") ? :exponentially_longer : :polynomially_longer
 
       def perform(webhook:, **webhook_args)
         webhook.notify(**webhook_args)

--- a/spec/rails/defaults/Gemfile.lock
+++ b/spec/rails/defaults/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    flipper-notifications (0.1.5)
+    flipper-notifications (0.1.6)
       activesupport (>= 7, < 8.1)
       flipper (>= 0.24, < 2.0)
       httparty (~> 0.17)
@@ -209,7 +209,7 @@ DEPENDENCIES
   web-console
 
 RUBY VERSION
-   ruby 3.1.2p20
+   ruby 3.2.2p53
 
 BUNDLED WITH
-   2.3.11
+   2.6.3

--- a/spec/rails/defaults/config/boot.rb
+++ b/spec/rails/defaults/config/boot.rb
@@ -1,4 +1,5 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
+require "logger"
 require "bundler/setup" # Set up gems listed in the Gemfile.
 require "bootsnap/setup" # Speed up boot time by caching expensive operations.


### PR DESCRIPTION
* ~`bundle update --bundler`~
* Quoting ruby versions in build matrix (my theory is that the number 3.0 is getting interpreted as just 3, which translates to the latest Ruby version (3.4) 😲 )
* Fixing a Gem version comparison bug in Ruby 3
* Scheduling a nightly build so that build issues get raised more quickly
* Requiring `logger` before booting Rails to fix Rails 7.0 test matrix