### PR TITLE
Add webhook_character_limit config param

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,9 @@ Metrics/CyclomaticComplexity:
 Metrics/MethodLength:
   Enabled: false
 
+Metrics/PerceivedComplexity:
+  Enabled: false
+
 Style/Documentation:
   Enabled: false
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,26 @@ Flipper::Notifications.configure do |config|
 end
 ```
 
+### Slack invalid_blocks Errors
+
+Slack limits the size of webhook messages.  The Slack API returns a 400 status
+code in these cases with a message of `invalid_blocks`. If your feature is
+enabled for a lot of actors or a lot of groups, the length of the list of
+actor or group names can exceed Slack's limit.  To avoid these errors, you
+may configure a character limit sent in webhooks by configuring a
+`webhook_character_limit` in your initializer:
+
+```ruby
+# config/initializers/flipper.rb
+
+Flipper::Notifications.configure do |config|
+  config.webhook_character_limit = 40_000
+end
+```
+
+If you set this value, webhook messages will be shortened whenever they
+exceed the configured character limit.
+
 ### Implementing Your Own Webhooks
 
 This gem provides an implementation to send notifications to Slack via an

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ may configure a character limit sent in webhooks by configuring a
 # config/initializers/flipper.rb
 
 Flipper::Notifications.configure do |config|
-  config.webhook_character_limit = 40_000
+  config.webhook_character_limit = 3_000
 end
 ```
 

--- a/lib/flipper/notifications/configuration.rb
+++ b/lib/flipper/notifications/configuration.rb
@@ -7,9 +7,10 @@ module Flipper
       def initialize
         @enabled   = false
         @notifiers = []
+        @webhook_character_limit = nil
       end
 
-      attr_accessor :enabled, :notifiers
+      attr_accessor :enabled, :notifiers, :webhook_character_limit
 
       def enabled?
         @enabled

--- a/lib/flipper/notifications/feature_event.rb
+++ b/lib/flipper/notifications/feature_event.rb
@@ -40,7 +40,7 @@ module Flipper
       def feature_enabled_settings_markdown
         return "" unless feature.conditional?
 
-        [].tap do |settings|
+        markdown = [].tap do |settings|
           settings << "The feature is now enabled for:" if feature.conditional?
 
           settings << "- Groups: #{to_sentence(feature.enabled_groups.map(&:name).sort)}" if feature.enabled_groups.any?
@@ -53,6 +53,11 @@ module Flipper
 
           settings << "- #{feature.percentage_of_time_value}% of the time" if feature.percentage_of_time_value.positive?
         end.join("\n")
+
+        character_limit = Flipper::Notifications.configuration.webhook_character_limit
+        return markdown if character_limit.nil? || markdown.length <= character_limit
+
+        shortened_feature_enabled_settings_markdown[0...character_limit]
       end
 
       def noteworthy?
@@ -95,6 +100,21 @@ module Flipper
         else
           "#{words[0...-1].join(', ')} and #{words.last}"
         end
+      end
+
+      def shortened_feature_enabled_settings_markdown
+        [].tap do |settings|
+          settings << "The feature is now enabled for:" if feature.conditional?
+
+          settings << "#{feature.enabled_groups.size} Groups" if feature.enabled_groups.any?
+          settings << "#{feature.actors_value.size} Actors" if feature.actors_value.any?
+
+          if feature.percentage_of_actors_value.positive?
+            settings << "- #{feature.percentage_of_actors_value}% of actors"
+          end
+
+          settings << "- #{feature.percentage_of_time_value}% of the time" if feature.percentage_of_time_value.positive?
+        end.join("\n")
       end
 
     end

--- a/spec/flipper/notifications/feature_event_spec.rb
+++ b/spec/flipper/notifications/feature_event_spec.rb
@@ -94,6 +94,10 @@ RSpec.describe Flipper::Notifications::FeatureEvent do
   describe "#feature_enabled_settings_markdown" do
     subject(:markdown) { event.feature_enabled_settings_markdown }
 
+    before do
+      Flipper::Notifications.configuration.webhook_character_limit = nil
+    end
+
     context "when the feature is fully enabled" do
       before do
         feature.enable
@@ -140,6 +144,20 @@ RSpec.describe Flipper::Notifications::FeatureEvent do
         feature.enable_actor(user3)
 
         expect(markdown).to match(/Actors: #{user.flipper_id}, #{user2.flipper_id} and #{user3.flipper_id}/)
+      end
+
+      it "includes a number of actors that exceeds the markdown_list_item_limit" do
+        Flipper::Notifications.configuration.webhook_character_limit = 60
+
+        user = User.new(id: 1)
+        user2 = User.new(id: 2)
+        user3 = User.new(id: 3)
+        feature.enable_actor(user)
+        feature.enable_actor(user2)
+        feature.enable_actor(user3)
+
+        expect(markdown).not_to match(/Actors: #{user.flipper_id}, #{user2.flipper_id} and #{user3.flipper_id}/)
+        expect(markdown).to match(/3 Actors/)
       end
 
       it "includes percentage of actors" do


### PR DESCRIPTION
Slack limits the size of webhook messages.  The Slack API returns a 400 status code in these cases with a message of `invalid_blocks`. If your feature is enabled for a lot of actors or a lot of groups, the length of the list of actor or group names can exceed Slack's limit.

This PR introduces a  `webhook_character_limit` configuration param to avoid these 400 errors from Slack.  If you configure this value, webhook messages will be shortened whenever they exceed the configured character limit.  To shorten the messages, we remove the individual actor and/or group names and instead generate something like "2,000 Groups" or "5,000 Actors".  Summarized information posted to Slack is probably better than no information 😃 .

The CI build for this gem is a little borked, so I will probably have to merge without the Rails 3.2 specs passing 😬 .